### PR TITLE
Refactors backend/scripts/build.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /web/www/typings
 /web/www/dist
 /out
+/work-directory

--- a/backend/scripts/build.sh
+++ b/backend/scripts/build.sh
@@ -5,4 +5,7 @@ set -e
 dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 root=$dir/../..
 
-docker run -v $root/:/workspace --rm java:8-jdk bash -ce "(cd workspace/backend; ../gradlew build)"
+uid=$(id -u)
+gid=$(id -g)
+
+docker run -v $root/:/workspace -u $uid:$gid -e GRADLE_USER_HOME=/workspace/work-directory --rm openjdk:8-jdk bash -ce "(cd workspace/backend; ../gradlew build)"


### PR DESCRIPTION
- Adds uid and gid mapping to avoid persmission mismatch (root vs local user) after run of script
- Switches from deprecated java to openjdk image
- Sets GRADLE_USER_HOME to avoid cryptic folders, such as '?', genereated by the Gradle wrapper